### PR TITLE
fix import error in gosnmp_api_test.go

### DIFF
--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soniah/gosnmp"
+	"github.com/slayercat/gosnmp"
 )
 
 func TestAPIConfigTypes(t *testing.T) {


### PR DESCRIPTION
it will cause go module error when use this library